### PR TITLE
Enhance agent fallback behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ This project demonstrates the use of the Google Agent Development Kit (ADK) to c
 - Integrates with Google Search.
 - Uses the `gemini-2.5-flash-preview-04-17` model for streaming responses.
 - Supports `python-dotenv` for environment variable management.
+- When none of the built-in tools fit a request, the agent can generate a short
+  Python script and execute it through the MCP code executor, asking for
+  confirmation if additional steps are required.
 
 ## Installation
 

--- a/mcp_agent.py
+++ b/mcp_agent.py
@@ -211,6 +211,11 @@ async def async_main():
 - For filesystem operations (e.g., read, write, list files, save content to files in the 'agent_files' directory), delegate to filesystem_agent.
 - For web searches, including tasks that require analyzing content from specific URLs or grounding responses with web content, delegate to search_agent. This agent can perform Google searches and use URL content for comprehensive answers.
 - For executing code snippets, delegate to mcp_code_executor_agent.
+- If none of the available tools can accomplish the user's request, propose a
+  short Python script that would solve the problem and ask the user for
+  confirmation before delegating its execution to `mcp_code_executor_agent`. If
+  that execution fails or reveals additional steps, suggest an alternative plan
+  and ask whether to proceed.
 - For fetching content from a specific URL (e.g., "fetch example.com", "get content of page X as markdown"), delegate to fetch_agent. This agent can use tools like `fetch` (to get content, optionally as markdown) and `fetch_and_search` (to get content and search within it using regex).
 - For scraping content from web sources:
     - Delegate to content_scraper_agent. This agent can use tools like `scrape_rss`, `scrape_reddit`, and `scrape_twitter`.


### PR DESCRIPTION
## Summary
- document ability to auto-generate Python code when tools are insufficient
- instruct root agent to suggest generating code via `mcp_code_executor_agent` when no tool fits

## Testing
- `python -m py_compile mcp_agent.py mcp_agent_utils.py`